### PR TITLE
Updated to CirrusMDSDK 1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CirrusMD iOS SDK Changelog
 
+# 1.9.2
+
+Built with:
+- Xcode 11.4, Swift 5.2
+
+Enhancements:
+
+- Updated pinned SSL certificates
+
+--- 
+# DEPRECATED: All builds below this line are deprecated and will not work starting on 10/02/2020
+
 # 1.9.1
 
 Built with:

--- a/Podfile
+++ b/Podfile
@@ -9,11 +9,11 @@ workspace 'CirrusMDSDK-Example.xcworkspace'
 
 target 'CirrusMDSDK-Pods' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 1.9.1'
+  pod 'CirrusMDSDK', '~> 1.9.2'
 end
 
 target 'CirrusMDSDK-Pods-ObjC' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 1.9.1'
+  pod 'CirrusMDSDK', '~> 1.9.2'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CirrusMDSDK (1.9.1):
+  - CirrusMDSDK (1.9.2):
     - JTSImageViewController (~> 1.5.1)
     - Kingfisher (~> 5.8.1)
     - KTVJSONWebToken (~> 2.1.0)
@@ -18,7 +18,7 @@ PODS:
   - Kingfisher/Core (5.8.3)
   - KTVJSONWebToken (2.1.0)
   - MBProgressHUD (1.1.0)
-  - ObjectMapper (3.5.2)
+  - ObjectMapper (3.5.3)
   - OpenTok (2.16.6)
   - ReachabilitySwift (4.3.1)
   - RNCryptor (5.1.0)
@@ -28,7 +28,7 @@ PODS:
   - UDF (0.7.0)
 
 DEPENDENCIES:
-  - CirrusMDSDK (~> 1.9.1)
+  - CirrusMDSDK (~> 1.9.2)
 
 SPEC REPOS:
   https://github.com/CirrusMD/podspecs.git:
@@ -48,12 +48,12 @@ SPEC REPOS:
     - Then
 
 SPEC CHECKSUMS:
-  CirrusMDSDK: 28a790cc1f631bec9ce96a073c96c97acace0000
+  CirrusMDSDK: 8d368eb6b7996ef2372e606906fc80ec689fa7e5
   JTSImageViewController: 1f8ce1cc93dab0d0af8e53badeea7528560cfec9
   Kingfisher: b7e4cb65ff24c264bd2a1284b75b974d907afd94
   KTVJSONWebToken: c3cc06e26876d63c62a5c40c5e89939899de48cf
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
-  ObjectMapper: b53ae947d370bf89423e86be7d4e2d2b2a8d3f40
+  ObjectMapper: 97111c97e054a6ee25917662106689f0b4127b37
   OpenTok: 85ce78080020035425aa1a317f2ff5a0fcc1e265
   ReachabilitySwift: 4032e2f59586e11e3b0ebe15b167abdd587a388b
   RNCryptor: a369134686cd2ad391323cc856b62e591193ba79
@@ -62,6 +62,6 @@ SPEC CHECKSUMS:
   Then: 90cd104fd951cec1980a03f57704ad8f784d4d79
   UDF: fe8d48fbc2187db4a0d888e29427a5916cc062f7
 
-PODFILE CHECKSUM: 34cc86878d291cfad326f223de53cf355b1c36bd
+PODFILE CHECKSUM: 0476bbee4713c3a4e166f7fcffd1e5aba12fe011
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
## Description
- Update CirrusMDSDK to 1.9.2.
- Added deprecation notice to CHANGELOG.

## Motivation and Context
Version 1.9.2 of the CirrusMDSDK contains updates to the pinned certificates.

Deprecation note: All version older than 1.9.2 are deprecated and will not work starting on 10/02/2020. This note has been added to the CHANGELOG

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added tests to cover my changes.
- [x] No tests are required for this change.
- [ ] My change requires a documentation change.
- [x] My change requires a CHANGELOG update.
