### PR TITLE
Update CHANGELOG to include 1.9.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CirrusMD iOS SDK Changelog
 
+# 1.9.3
+
+Built with:
+- Xcode 11.3.1, Swift 5.1
+
+Note:
+- This is the same change as 1.9.2 but it is built off of 1.9.0 with Xcode 11.3.1 and Swift 5.1
+
+Enhancements:
+
+- Updated pinned SSL certificates
+
 # 1.9.2
 
 Built with:


### PR DESCRIPTION
## Description
- Updated the CHANGELOG to include 1.9.3
- Note: 1.9.3 is the same change as 1.9.2 but is built off of 1.9.0 with Xcode 11.3.1 and Swift 5.1

## Motivation and Context
Some consumers need a version of the 1.9.2 change that was built with an older version of Xcode (11.3.1 specifically) and based off of 1.9.0 instead of 1.9.1.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added tests to cover my changes.
- [x] No tests are required for this change.
- [ ] My change requires a documentation change.
- [x] My change requires a CHANGELOG update.
