### PR TITLE
Update CirrusMDSDK to 1.9.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CirrusMD iOS SDK Changelog
 
+# 1.9.4
+
+Built with:
+- Xcode 11.6, Swift 5.2
+
+Enhancements:
+
+- Updated build to Xcode 11.6
+
 # 1.9.3
 
 Built with:

--- a/Podfile
+++ b/Podfile
@@ -9,11 +9,11 @@ workspace 'CirrusMDSDK-Example.xcworkspace'
 
 target 'CirrusMDSDK-Pods' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 1.9.2'
+  pod 'CirrusMDSDK', '~> 1.9.4'
 end
 
 target 'CirrusMDSDK-Pods-ObjC' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 1.9.2'
+  pod 'CirrusMDSDK', '~> 1.9.4'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CirrusMDSDK (1.9.2):
+  - CirrusMDSDK (1.9.4):
     - JTSImageViewController (~> 1.5.1)
     - Kingfisher (~> 5.8.1)
     - KTVJSONWebToken (~> 2.1.0)
@@ -28,7 +28,7 @@ PODS:
   - UDF (0.7.0)
 
 DEPENDENCIES:
-  - CirrusMDSDK (~> 1.9.2)
+  - CirrusMDSDK (~> 1.9.4)
 
 SPEC REPOS:
   https://github.com/CirrusMD/podspecs.git:
@@ -48,7 +48,7 @@ SPEC REPOS:
     - Then
 
 SPEC CHECKSUMS:
-  CirrusMDSDK: 8d368eb6b7996ef2372e606906fc80ec689fa7e5
+  CirrusMDSDK: 68a201908223d7d54e28a74912ade7fad10b17e0
   JTSImageViewController: 1f8ce1cc93dab0d0af8e53badeea7528560cfec9
   Kingfisher: b7e4cb65ff24c264bd2a1284b75b974d907afd94
   KTVJSONWebToken: c3cc06e26876d63c62a5c40c5e89939899de48cf
@@ -62,6 +62,6 @@ SPEC CHECKSUMS:
   Then: 90cd104fd951cec1980a03f57704ad8f784d4d79
   UDF: fe8d48fbc2187db4a0d888e29427a5916cc062f7
 
-PODFILE CHECKSUM: 0476bbee4713c3a4e166f7fcffd1e5aba12fe011
+PODFILE CHECKSUM: 2f6f66b96975b85ce3426b1cbe9f6e4e9bfc2417
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.3


### PR DESCRIPTION
## Description
Updated CirrusMDSDK to 1.9.4.

## Motivation and Context
Version 1.9.4 of the CirrusMDSDK does not contain any code changes from the previous version. It was simply recompiled with Xcode 11.6.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added tests to cover my changes.
- [x] No tests are required for this change.
- [ ] My change requires a documentation change.
- [x] My change requires a CHANGELOG update.
