### PR TITLE
8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CirrusMD iOS SDK Changelog
 
+# 8.0.1
+
+### Changes:
+- Updated the Appboy (aka Braze) dependency to version 4.0.2
+
 # 8.0.0
 
 ### New Features:

--- a/Podfile
+++ b/Podfile
@@ -9,11 +9,11 @@ workspace 'CirrusMDSDK-Example.xcworkspace'
 
 target 'CirrusMDSDK-Pods' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 8.0.0'
+  pod 'CirrusMDSDK', '~> 8.0.1'
 end
 
 target 'CirrusMDSDK-Pods-ObjC' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 8.0.0'
+  pod 'CirrusMDSDK', '~> 8.0.1'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
-  - Appboy-iOS-SDK (3.32.0):
-    - Appboy-iOS-SDK/UI (= 3.32.0)
-  - Appboy-iOS-SDK/ContentCards (3.32.0):
+  - Appboy-iOS-SDK (4.0.2):
+    - Appboy-iOS-SDK/UI (= 4.0.2)
+  - Appboy-iOS-SDK/ContentCards (4.0.2):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/Core (3.32.0)
-  - Appboy-iOS-SDK/InAppMessage (3.32.0):
+  - Appboy-iOS-SDK/Core (4.0.2)
+  - Appboy-iOS-SDK/InAppMessage (4.0.2):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/NewsFeed (3.32.0):
+  - Appboy-iOS-SDK/NewsFeed (4.0.2):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/UI (3.32.0):
+  - Appboy-iOS-SDK/UI (4.0.2):
     - Appboy-iOS-SDK/ContentCards
     - Appboy-iOS-SDK/Core
     - Appboy-iOS-SDK/InAppMessage
     - Appboy-iOS-SDK/NewsFeed
-  - CirrusMDSDK (8.0.0):
-    - Appboy-iOS-SDK (~> 3.32.0)
+  - CirrusMDSDK (8.0.1):
+    - Appboy-iOS-SDK (~> 4.0.2)
     - CMDKTVJSONWebToken (~> 2.1.0)
     - CMDMBProgressHUD (~> 1.2.0)
     - CMDStarscream (~> 3.1.1)
@@ -32,14 +32,14 @@ PODS:
     - Kingfisher/Core (= 5.15.8)
   - Kingfisher/Core (5.15.8)
   - OpenTok (2.18.1)
-  - SDWebImage (5.10.4):
-    - SDWebImage/Core (= 5.10.4)
-  - SDWebImage/Core (5.10.4)
+  - SDWebImage (5.11.1):
+    - SDWebImage/Core (= 5.11.1)
+  - SDWebImage/Core (5.11.1)
   - SnapKit (5.0.1)
   - UDF (0.7.0)
 
 DEPENDENCIES:
-  - CirrusMDSDK (~> 8.0.0)
+  - CirrusMDSDK (~> 8.0.1)
 
 SPEC REPOS:
   https://github.com/CirrusMD/podspecs.git:
@@ -56,17 +56,17 @@ SPEC REPOS:
     - SnapKit
 
 SPEC CHECKSUMS:
-  Appboy-iOS-SDK: 6d3016581cb5306e26826ec7333f0c5ae59e2a2f
-  CirrusMDSDK: 0cea66e68498e2b93a857883860c70ea1aa73752
+  Appboy-iOS-SDK: a423c382ef27ff998c8aa7b6ee81541c35687341
+  CirrusMDSDK: 0020b5fa12dac5b40135b9550cafb9cbe751cf07
   CMDKTVJSONWebToken: bb69c614202fddb946644202ca3bedb0c2fbe648
   CMDMBProgressHUD: ba79c6445bd58c9588d10c18d9dc0fe844a3e1d0
   CMDStarscream: 5a1bdbce0aea1db47cc418e248cadf9dc30eee89
   Kingfisher: a3c03d702433fa6cfedabb2bddbe076fb8f2e902
   OpenTok: 2a816f5d77fbf2e2ebb5aec841bd21fb7dc7737b
-  SDWebImage: c666b97e1fa9c64b4909816a903322018f0a9c84
+  SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   UDF: fe8d48fbc2187db4a0d888e29427a5916cc062f7
 
-PODFILE CHECKSUM: 8bb7b85e3b4b29697cbe544336d28fa758109905
+PODFILE CHECKSUM: b157c584b937bb3e75c28b47c967a888f37cb5fe
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1


### PR DESCRIPTION
## Description
Updated CirrusMDSDK to 8.0.1

## Motivation and Context
Version 8.0.1 of CirrusMDSDK updates the Appboy (aka Braze) dependency to version 4.0.2. This was done to assist an SDK consumer that had a conflict on this dependency.

**Note:** The Appboy (aka Braze) dependency will be removed entirely in an upcoming release.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added tests to cover my changes.
- [x] No tests are required for this change.
- [ ] My change requires a documentation change.
- [x] My change requires a CHANGELOG update.
