### PR TITLE
11.2.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,17 @@
 ## Built with: Xcode 14.3.1
 
 ### Changes:
-- Added `patient_goals_enabled` to `sdk/v2/customer` object parsing
-- if `patient_goals_enabled` is true, show patient goals cell below stream cells
-- Added Patient Goal cell type to the chat stream as a new design for universal card
-- Added `sdk/v2/patients/{patient_id}/goals` request
-- Created PatientGoals data object to represents patient goals
-- created `PatientGoalsViewController` that lists all patient goals arranged by status and in order returned by back end
-- Created an empty state for `PatientGoalsViewController` and an empty state for each goal section
-- localized patient goal associated hard coded strings
-- modified `UniversalCardCell` for right aligned bar layout
-- Update and refactor for Stream Info View to allow inactive to grow and shrink for lots of text
+- Added a new Patient Health Goal feature:
+    - Added a new message view for Patient Health Goals, that show up in the chat stream.
+    - New scrollable Patient Health Goals screen, where patients can see all Active, Upcoming, and Completed goals.
+- Updated AmazonChimeSDK-No-Bitcode to 0.23.3
 
 ### Bug Fixes:
+- Fixed issue where inactive stream messages can consume the entire screen (when message is long, or accessibility font is being used), causing a bad user experience. The new behavior involves having a collapsable message, which the user can expand and collapse.
 - Fixes animations with Stream Info to reduce flashing and clean up execution order
+
+### Known Issues:
+- We are currently tracking an issue when building this SDK on Xcode 15.0 related to dark mode. Any customer planning to build on Xcode 15 should wait for 11.3.0 of our SDK.
 
 # 11.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CirrusMD iOS SDK Changelog
 
+# 11.2.0
+
+## Built with: Xcode 14.3.1
+
+### Changes:
+- Added `patient_goals_enabled` to `sdk/v2/customer` object parsing
+- if `patient_goals_enabled` is true, show patient goals cell below stream cells
+- Added Patient Goal cell type to the chat stream as a new design for universal card
+- Added `sdk/v2/patients/{patient_id}/goals` request
+- Created PatientGoals data object to represents patient goals
+- created `PatientGoalsViewController` that lists all patient goals arranged by status and in order returned by back end
+- Created an empty state for `PatientGoalsViewController` and an empty state for each goal section
+- localized patient goal associated hard coded strings
+- modified `UniversalCardCell` for right aligned bar layout
+- Update and refactor for Stream Info View to allow inactive to grow and shrink for lots of text
+
+### Bug Fixes:
+- Fixes animations with Stream Info to reduce flashing and clean up execution order
+
 # 11.1.0
 
 ## Built with: Xcode 14.3.1

--- a/Podfile
+++ b/Podfile
@@ -9,10 +9,10 @@ workspace 'CirrusMDSDK-Example.xcworkspace'
 
 target 'CirrusMDSDK-Pods' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 11.1.0'
+  pod 'CirrusMDSDK', '~> 11.2.0'
 end
 
 target 'CirrusMDSDK-Pods-ObjC' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 11.1.0'
+  pod 'CirrusMDSDK', '~> 11.2.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - AmazonChimeSDK-No-Bitcode (0.23.1):
-    - AmazonChimeSDKMedia-No-Bitcode (= 0.18.1)
-  - AmazonChimeSDKMedia-No-Bitcode (0.18.1)
-  - CirrusMDSDK (11.1.0):
+  - AmazonChimeSDK-No-Bitcode (0.23.3):
+    - AmazonChimeSDKMedia-No-Bitcode (= 0.18.3)
+  - AmazonChimeSDKMedia-No-Bitcode (0.18.3)
+  - CirrusMDSDK (11.2.0):
     - AmazonChimeSDK-No-Bitcode (~> 0.23.1)
     - Kingfisher (~> 7.6.2)
   - Kingfisher (7.6.2)
 
 DEPENDENCIES:
-  - CirrusMDSDK (~> 11.1.0)
+  - CirrusMDSDK (~> 11.2.0)
 
 SPEC REPOS:
   https://github.com/CirrusMD/podspecs.git:
@@ -19,11 +19,11 @@ SPEC REPOS:
     - Kingfisher
 
 SPEC CHECKSUMS:
-  AmazonChimeSDK-No-Bitcode: 19655be98d0e3facea16f716031c159d555d54c3
-  AmazonChimeSDKMedia-No-Bitcode: 6afd3148ff5ea8924c276612259882fbe548ca3f
-  CirrusMDSDK: 0874904942ebf3c0257f946b721ad1d74017695f
+  AmazonChimeSDK-No-Bitcode: d4aae9b4732e937463fbe078b67b969a693831d9
+  AmazonChimeSDKMedia-No-Bitcode: 181571b340454987d9a7a21074ac675e67d660b4
+  CirrusMDSDK: 15104368b61119687e52417828505a304d4a8d92
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
 
-PODFILE CHECKSUM: c049107dde90ac7bb55dcebe6112a1f452ba5a95
+PODFILE CHECKSUM: 7dc036d9b627b76057204895716682c25489e94d
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.14.2


### PR DESCRIPTION
## Description
### 11.2.0, Built with: Xcode 14.3.1

### Changes:
- Added a new Patient Health Goal feature:
    - Added a new message view for Patient Health Goals, that show up in the chat stream.
    - New scrollable Patient Health Goals screen, where patients can see all Active, Upcoming, and Completed goals.
- Updated AmazonChimeSDK-No-Bitcode to 0.23.3

### Bug Fixes:
- Fixed issue where inactive stream messages can consume the entire screen (when message is long, or accessibility font is being used), causing a bad user experience. The new behavior involves having a collapsable message, which the user can expand and collapse.
- Fixes animations with Stream Info to reduce flashing and clean up execution order

### Known Issues:
- We are currently tracking an issue when building this SDK on Xcode 15.0 related to dark mode. Any customer planning to build on Xcode 15 should wait for 11.3.0 of our SDK.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added tests to cover my changes.
- [ ] No tests are required for this change.
- [x] My change requires a documentation change.
- [x] My change requires a CHANGELOG update.
