### PR TITLE
11.6.0

### DIFF
--- a/CirrusMDSDK-Example.xcodeproj/project.pbxproj
+++ b/CirrusMDSDK-Example.xcodeproj/project.pbxproj
@@ -325,8 +325,8 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-CirrusMDSDK-Pods-ObjC/Pods-CirrusMDSDK-Pods-ObjC-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AmazonChimeSDK-No-Bitcode/AmazonChimeSDK.framework/AmazonChimeSDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AmazonChimeSDKMedia-No-Bitcode/AmazonChimeSDKMedia.framework/AmazonChimeSDKMedia",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AmazonChimeSDK/AmazonChimeSDK.framework/AmazonChimeSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AmazonChimeSDKMedia/AmazonChimeSDKMedia.framework/AmazonChimeSDKMedia",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/CirrusMDSDK/CirrusMDSDK.framework/CirrusMDSDK",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -349,8 +349,8 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-CirrusMDSDK-Pods/Pods-CirrusMDSDK-Pods-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AmazonChimeSDK-No-Bitcode/AmazonChimeSDK.framework/AmazonChimeSDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AmazonChimeSDKMedia-No-Bitcode/AmazonChimeSDKMedia.framework/AmazonChimeSDKMedia",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AmazonChimeSDK/AmazonChimeSDK.framework/AmazonChimeSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AmazonChimeSDKMedia/AmazonChimeSDKMedia.framework/AmazonChimeSDKMedia",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/CirrusMDSDK/CirrusMDSDK.framework/CirrusMDSDK",
 			);
 			name = "[CP] Embed Pods Frameworks";

--- a/Podfile
+++ b/Podfile
@@ -9,10 +9,10 @@ workspace 'CirrusMDSDK-Example.xcworkspace'
 
 target 'CirrusMDSDK-Pods' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 11.5.0'
+  pod 'CirrusMDSDK', '~> 11.6.0'
 end
 
 target 'CirrusMDSDK-Pods-ObjC' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 11.5.0'
+  pod 'CirrusMDSDK', '~> 11.6.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
-  - AmazonChimeSDK-No-Bitcode (0.23.3):
-    - AmazonChimeSDKMedia-No-Bitcode (= 0.18.3)
-  - AmazonChimeSDKMedia-No-Bitcode (0.18.3)
-  - CirrusMDSDK (11.5.0):
-    - AmazonChimeSDK-No-Bitcode (~> 0.23.3)
-    - Kingfisher (~> 7.9.1)
-  - Kingfisher (7.9.1)
+  - AmazonChimeSDK (0.25.2):
+    - AmazonChimeSDKMedia (= 0.21.0)
+  - AmazonChimeSDKMedia (0.21.0)
+  - CirrusMDSDK (11.6.0):
+    - AmazonChimeSDK (~> 0.25.0)
+    - Kingfisher (~> 7.11.0)
+  - Kingfisher (7.11.0)
 
 DEPENDENCIES:
-  - CirrusMDSDK (~> 11.5.0)
+  - CirrusMDSDK (~> 11.6.0)
 
 SPEC REPOS:
   https://github.com/CirrusMD/podspecs.git:
     - CirrusMDSDK
   https://github.com/CocoaPods/Specs.git:
-    - AmazonChimeSDK-No-Bitcode
-    - AmazonChimeSDKMedia-No-Bitcode
+    - AmazonChimeSDK
+    - AmazonChimeSDKMedia
     - Kingfisher
 
 SPEC CHECKSUMS:
-  AmazonChimeSDK-No-Bitcode: d4aae9b4732e937463fbe078b67b969a693831d9
-  AmazonChimeSDKMedia-No-Bitcode: 181571b340454987d9a7a21074ac675e67d660b4
-  CirrusMDSDK: a545ab625f3bacea8f2d1186e80bba744fade08e
-  Kingfisher: 1d14e9f59cbe19389f591c929000332bf70efd32
+  AmazonChimeSDK: bdb9479c634afbee3e3a36a70a2a8ebb40742e5b
+  AmazonChimeSDKMedia: e5cfbc52926d864c03a86bf07caea4b33c745517
+  CirrusMDSDK: cb3b4808d90ffc3dd2fe3a18fcd1d7316c712d73
+  Kingfisher: b9c985d864d43515f404f1ef4a8ce7d802ace3ac
 
-PODFILE CHECKSUM: 73e6029080d5fc9d8d3b89e8f2710c685238d2ea
+PODFILE CHECKSUM: 75c3cf5829faf676cee898ad3bb094ff5714ca23
 
 COCOAPODS: 1.14.2


### PR DESCRIPTION
## Description
### Shared:
- Updated Pods:
  - AmazonChimeSDK 0.25.0 (https://github.com/aws/amazon-chime-sdk-ios/releases)
  - AmazonChimeSDKMedia 0.20.0 (https://github.com/aws/amazon-chime-sdk-ios/releases)
  - Kingfisher 7.11.0 (https://github.com/onevcat/Kingfisher/releases)
  - Removed AmazonChimeSDK-No-Bitcode
  - Removed AmazonChimeSDKMedia-No-Bitcode
- Updated Concurrency for UI related to to be properly marked as `@MainActor`
- Integrated Swift MarkdownKit to handle Markdown Parsing to the wrapper and SDK
- Full landscape rotational support for SDK and all white labels

### SDK Only:
- Added `CMDSignatureVC` to allow for documents to be signed from the SDK
- Improved settings profile, medical and family design to get closer to parity with Android
- Fixed iPad navigation for family dependent profile settings
- Removed deprecated UITableViewCell layout code
- Added `requestInAppReview` functionality to `CirrusMDDelegate` to notifiy the SDK parent app when to present in app Appstore rating prompt
- Added new `ActionMessageFormScreenVC` for handling document signing in App
- Refactored `Assesments` and `ActionMessages` to support the new strucutre
- Added support for in app Appstore review prompt
- Added new `DataSharing` row to settings
- Added `DataSharingVC` that shows main patient and all dependents HIE data sharing status
- Added ability to change data sharing preference from settings `Data Sharing` view

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added tests to cover my changes.
- [ ] No tests are required for this change.
- [ ] My change requires a documentation change.
- [ ] My change requires a CHANGELOG update.
