### PR TITLE
12.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CirrusMD iOS SDK Changelog
 
+# 12.2.0
+Xcode 16.4.0
+
+## Changes:
+- Updated Pods:
+  - Kingfisher 8.5.0 (https://github.com/onevcat/Kingfisher/releases)
+- Added `enableSecuritySettings` to CirrusMDConfig to show or hide the security cell in the Settings list
+- Added Delete Photo option for image picker for use on the patient profile
+- Refactor Provider Profile into a SwiftUI view
+- Refactor Support into a SwiftUI view
+- Rebuild of the Red Dot back button to work better in iOS 26 and be easier to see on older versions of iOS
+- Bug Fix for the text color of Cancel buttons in iOS 26
+- Added Medical Card Details and Medical Card selector screens
+- Added API calls and image handling for Medical Cards
+- Added share warning to all shares to warn patients they are sharing PHI
+- Added Don't remind me to share warning
+- Renamed Labs to Medical Documents and updated design to allow for Labs and Imaging tabs
+- Added navigation button to Medical Documents cells to navigate to stream
+
 # 12.1.0
 Xcode 16.4.0
 

--- a/Podfile
+++ b/Podfile
@@ -9,10 +9,10 @@ workspace 'CirrusMDSDK-Example.xcworkspace'
 
 target 'CirrusMDSDK-Pods' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 12.1.0'
+  pod 'CirrusMDSDK', '~> 12.2.0'
 end
 
 target 'CirrusMDSDK-Pods-ObjC' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 12.1.0'
+  pod 'CirrusMDSDK', '~> 12.2.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,13 +2,13 @@ PODS:
   - AmazonChimeSDK (0.27.1):
     - AmazonChimeSDKMedia (= 0.24.0)
   - AmazonChimeSDKMedia (0.24.0)
-  - CirrusMDSDK (12.1.0):
+  - CirrusMDSDK (12.2.0):
     - AmazonChimeSDK (~> 0.27.1)
-    - Kingfisher (~> 8.3.2)
-  - Kingfisher (8.3.3)
+    - Kingfisher (~> 8.5.0)
+  - Kingfisher (8.5.0)
 
 DEPENDENCIES:
-  - CirrusMDSDK (~> 12.1.0)
+  - CirrusMDSDK (~> 12.2.0)
 
 SPEC REPOS:
   https://github.com/CirrusMD/podspecs.git:
@@ -21,9 +21,9 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AmazonChimeSDK: d22c04d2a0991d3419730394ab8592f08dcddd71
   AmazonChimeSDKMedia: e8c7bca1b27eae702a06be4e89ad29f8913f38fd
-  CirrusMDSDK: 46e187b68d1f66e6e938ce6c97c753f195aa0816
-  Kingfisher: ff82cb91d9266ddb56cbb2f72d32c26f00d3e5be
+  CirrusMDSDK: 3cab4c1ffbfa26b9d37ad5eb58a72242efd194db
+  Kingfisher: ff0d31a1f07bdff6a1ebb3ba08b8e6e567b6500c
 
-PODFILE CHECKSUM: ae7b17f81500beb5227ddbeeba3c0285c8b96ca6
+PODFILE CHECKSUM: d187683fc9e639548ff89592d2b12e6d284032f7
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Changes:
- Updated Pods:
  - Kingfisher 8.5.0 (https://github.com/onevcat/Kingfisher/releases)
- Added `enableSecuritySettings` to CirrusMDConfig to show or hide the security cell in the Settings list
- Added Delete Photo option for image picker for use on the patient profile
- Refactor Provider Profile into a SwiftUI view
- Refactor Support into a SwiftUI view
- Rebuild of the Red Dot back button to work better in iOS 26 and be easier to see on older versions of iOS
- Bug Fix for the text color of Cancel buttons in iOS 26
- Added Medical Card Details and Medical Card selector screens
- Added API calls and image handling for Medical Cards
- Added share warning to all shares to warn patients they are sharing PHI
- Added Don't remind me to share warning
- Renamed Labs to Medical Documents and updated design to allow for Labs and Imaging tabs
- Added navigation button to Medical Documents cells to navigate to stream

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added tests to cover my changes.
- [ ] No tests are required for this change.
- [ ] My change requires a documentation change.
- [ ] My change requires a CHANGELOG update.
