### PR TITLE
13.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # CirrusMD iOS SDK Changelog
 
+# 13.0.1
+Xcode 26.2.0
+
+## Changes:
+
+- Bug Fix: 
+  - Right bar buttons items added to SDK config now work properly.
+
+# 13.0.0
+Xcode 26.2.0
+
+## Changes:
+
+- Updated Pods:
+  - Kingfisher 8.6.2 (https://github.com/onevcat/Kingfisher/releases)
+  - AmazonChimeSDK 0.27.2 (https://github.com/aws/amazon-chime-sdk-ios/releases)
+- Fixed bug where an empty profile update request could be sent
+- Updated dependencies to make them Sendable.
+- Updated dependency injector to work with new Coordinator system.
+- New Home Screen for the App.
+- New Main Menu in the Nav bar home screen.
+- Add Figtree Font to the SDK and use on New Homescreen.
+- Added `is_legacy_channels_of_care_enabled` to Customer for home screen design option.
+
+- Bug Fix: 
+  - Avatar Images No longer show empty on API error.
+
 # 12.3.1
 Xcode 26.1.1
 

--- a/CirrusMDSDK-Pods-ObjC/CMDWrapper.swift
+++ b/CirrusMDSDK-Pods-ObjC/CMDWrapper.swift
@@ -14,8 +14,8 @@ import UIKit
 
 public class CMDWrapper: NSObject {
     
-    @objc func startSDK(withLuanchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-        CirrusMD.singleton.startSDK(withLuanchOptions: withLuanchOptions)
+    @objc func startSDK(withLuanchOptions: [UIApplication.LaunchOptionsKey: any Sendable]?) {
+        CirrusMD.singleton.startSDK(withLaunchOptions: withLuanchOptions)
     }
     
     @objc func configureSDK(withButtonItems: [UIBarButtonItem]) {
@@ -29,6 +29,7 @@ public class CMDWrapper: NSObject {
         CirrusMD.singleton.setSDKConfiguration(config)
     }
     
+    @MainActor
     @objc func currentViewController() -> UIViewController? {
         return CirrusMD.singleton.viewController
     }

--- a/Podfile
+++ b/Podfile
@@ -9,10 +9,10 @@ workspace 'CirrusMDSDK-Example.xcworkspace'
 
 target 'CirrusMDSDK-Pods' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 12.3.1'
+  pod 'CirrusMDSDK', '~> 13.0.1'
 end
 
 target 'CirrusMDSDK-Pods-ObjC' do
   project 'CirrusMDSDK-Example.xcodeproj'
-  pod 'CirrusMDSDK', '~> 12.3.1'
+  pod 'CirrusMDSDK', '~> 13.0.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,13 +2,13 @@ PODS:
   - AmazonChimeSDK (0.27.2):
     - AmazonChimeSDKMedia (= 0.25.2)
   - AmazonChimeSDKMedia (0.25.2)
-  - CirrusMDSDK (12.3.1):
-    - AmazonChimeSDK (~> 0.27.1)
-    - Kingfisher (~> 8.6.0)
+  - CirrusMDSDK (13.0.1):
+    - AmazonChimeSDK (~> 0.27.2)
+    - Kingfisher (~> 8.6.2)
   - Kingfisher (8.6.2)
 
 DEPENDENCIES:
-  - CirrusMDSDK (~> 12.3.1)
+  - CirrusMDSDK (~> 13.0.1)
 
 SPEC REPOS:
   https://github.com/CirrusMD/podspecs.git:
@@ -21,9 +21,9 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AmazonChimeSDK: 2c044a2c3681ce10345b8764b0949ffcea8fc582
   AmazonChimeSDKMedia: eacef3520894eaebd920a943147873fa6c9fbc1a
-  CirrusMDSDK: 05a51e6a47e4c297e49e7352d5112be2b49085b3
+  CirrusMDSDK: 6607de804f57c2444ab8443b486977d5e7ed3059
   Kingfisher: 23d18f54677d973b713e54ce6a8f5eef6e7056ba
 
-PODFILE CHECKSUM: be5b4d22c39b805ea4d15a4be0bf8c0d5482f6af
+PODFILE CHECKSUM: c51e1b1c66e054574973540a4d44530907c9527d
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Description
# 13.0.1
Xcode 26.2.0

## Changes:

- Bug Fix: 
  - Right bar buttons items added to SDK config now work properly.

# 13.0.0
Xcode 26.2.0

## Changes:

- Updated Pods:
  - Kingfisher 8.6.2 (https://github.com/onevcat/Kingfisher/releases)
  - AmazonChimeSDK 0.27.2 (https://github.com/aws/amazon-chime-sdk-ios/releases)
- Fixed bug where an empty profile update request could be sent
- Updated dependencies to make them Sendable.
- Updated dependency injector to work with new Coordinator system.
- New Home Screen for the App.
- New Main Menu in the Nav bar home screen.
- Add Figtree Font to the SDK and use on New Homescreen.
- Added `is_legacy_channels_of_care_enabled` to Customer for home screen design option.

- Bug Fix: 
  - Avatar Images No longer show empty on API error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have added tests to cover my changes.
- [ ] No tests are required for this change.
- [ ] My change requires a documentation change.
- [x] My change requires a CHANGELOG update.
